### PR TITLE
Update dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY : tests clean install
 
 requirements.txt test-requirements.txt : %.txt : %.in setup.py
-	pip-compile -v $< --output-file $*.tmp
+	pip-compile --upgrade -v $< --output-file $*.tmp
 	./make_paths_relative.py < $*.tmp > $@
 
 install :

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,70 +6,75 @@
 #
 -e .
 appnope==0.1.0            # via ipython
-astroid==2.1.0            # via pylint
+astroid==2.2.5            # via pylint
 atomicwrites==1.3.0       # via pytest
-attrs==18.2.0             # via pytest
+attrs==19.1.0             # via jsonschema, pytest
 backcall==0.1.0           # via ipython
 bleach==3.1.0             # via nbconvert
-coverage==4.5.2           # via pytest-cov
+coverage==4.5.3           # via pytest-cov
 cycler==0.10.0            # via matplotlib
-decorator==4.3.2          # via ipython, networkx, traitlets
-defusedxml==0.5.0         # via nbconvert
+decorator==4.4.0          # via ipython, networkx, traitlets
+defusedxml==0.6.0         # via nbconvert
 entrypoints==0.3          # via nbconvert
-ipykernel==5.1.0          # via notebook
+importlib-metadata==0.18  # via pluggy, pytest
+ipykernel==5.1.1          # via notebook
 ipython-genutils==0.2.0   # via nbformat, notebook, traitlets
-ipython==7.3.0            # via ipykernel
-isort==4.3.4              # via pylint
-jedi==0.13.2              # via ipython
-jinja2==2.10              # via nbconvert, notebook
-jsonschema==2.6.0         # via jupyterlab-server, nbformat
-jupyter-client==5.2.4     # via ipykernel, notebook
-jupyter-core==4.4.0       # via jupyter-client, nbconvert, nbformat, notebook
-jupyterlab-server==0.2.0  # via jupyterlab
-jupyterlab==0.35.4
-kiwisolver==1.0.1         # via matplotlib
-lazy-object-proxy==1.3.1  # via astroid
-markupsafe==1.1.0         # via jinja2
-matplotlib==3.0.2
+ipython==7.6.1            # via ipykernel
+isort==4.3.21             # via pylint
+jedi==0.14.0              # via ipython
+jinja2==2.10.1            # via nbconvert, notebook
+json5==0.8.5              # via jupyterlab-server
+jsonschema==3.0.1         # via jupyterlab-server, nbformat
+jupyter-client==5.3.0     # via ipykernel, notebook
+jupyter-core==4.5.0       # via jupyter-client, nbconvert, nbformat, notebook
+jupyterlab-server==1.0.0  # via jupyterlab
+jupyterlab==1.0.1
+kiwisolver==1.1.0         # via matplotlib
+lazy-object-proxy==1.4.1  # via astroid
+markupsafe==1.1.1         # via jinja2
+matplotlib==3.1.1
 mccabe==0.6.1             # via pylint
 mistune==0.8.4            # via nbconvert
-more-itertools==6.0.0     # via pytest
-nbconvert==5.4.1          # via notebook
+more-itertools==7.1.0     # via pytest
+nbconvert==5.5.0          # via notebook
 nbformat==4.4.0           # via nbconvert, notebook
-networkx==2.2
+networkx==2.3
 notebook==5.7.8           # via jupyterlab, jupyterlab-server
-numpy==1.16.1             # via matplotlib, scipy
+numpy==1.16.4             # via matplotlib, scipy
+packaging==19.0           # via pytest
 pandocfilters==1.4.2      # via nbconvert
-parso==0.3.4              # via jedi
-pexpect==4.6.0            # via ipython
+parso==0.5.0              # via jedi
+pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pluggy==0.8.1             # via pytest
-prometheus-client==0.6.0  # via notebook
+pluggy==0.12.0            # via pytest
+prometheus-client==0.7.1  # via notebook
 prompt-toolkit==2.0.9     # via ipython
 ptyprocess==0.6.0         # via pexpect, terminado
 py==1.8.0                 # via pytest
-pygments==2.3.1           # via ipython, nbconvert
-pylint==2.2.2
-pyparsing==2.3.1          # via matplotlib
-pyproj==1.9.6
+pygments==2.4.2           # via ipython, nbconvert
+pylint==2.3.1
+pyparsing==2.4.0          # via matplotlib, packaging
+pyproj==2.2.1
+pyrsistent==0.15.3        # via jsonschema
 pyshp==2.1.0
-pytest-cov==2.6.1
-pytest==4.3.0             # via pytest-cov
+pytest-cov==2.7.1
+pytest==5.0.1             # via pytest-cov
 python-dateutil==2.8.0    # via jupyter-client, matplotlib
-pyzmq==18.0.0             # via jupyter-client, notebook
-scipy==1.2.1
+pyzmq==18.0.2             # via jupyter-client, notebook
+scipy==1.3.0
 send2trash==1.5.0         # via notebook
 shapely==1.6.4.post2
-six==1.12.0               # via astroid, bleach, cycler, prompt-toolkit, pytest, python-dateutil, traitlets
-terminado==0.8.1          # via notebook
+six==1.12.0               # via astroid, bleach, cycler, jsonschema, packaging, prompt-toolkit, pyrsistent, python-dateutil, traitlets
+terminado==0.8.2          # via notebook
 testpath==0.4.2           # via nbconvert
-tornado==5.1.1            # via ipykernel, jupyter-client, notebook, terminado
+tornado==6.0.3            # via ipykernel, jupyter-client, jupyterlab, notebook, terminado
 tqdm==4.32.2
 traitlets==4.3.2          # via ipykernel, ipython, jupyter-client, jupyter-core, nbconvert, nbformat, notebook
-typed-ast==1.3.1          # via astroid
-wcwidth==0.1.7            # via prompt-toolkit
+typed-ast==1.4.0          # via astroid
+wcwidth==0.1.7            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.11.1             # via astroid
+wrapt==1.11.2             # via astroid
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via ipython, kiwisolver, pytest
+# setuptools==41.0.1        # via ipython, jsonschema, kiwisolver

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,21 +6,25 @@
 #
 -e .
 atomicwrites==1.3.0       # via pytest
-attrs==18.2.0             # via pytest
-coverage==4.5.2           # via pytest-cov
+attrs==19.1.0             # via pytest
+coverage==4.5.3           # via pytest-cov
 cycler==0.10.0            # via matplotlib
-kiwisolver==1.0.1         # via matplotlib
-matplotlib==3.0.2
-more-itertools==6.0.0     # via pytest
-numpy==1.16.1             # via matplotlib, scipy
-pluggy==0.8.1             # via pytest
+importlib-metadata==0.18  # via pluggy, pytest
+kiwisolver==1.1.0         # via matplotlib
+matplotlib==3.1.1
+more-itertools==7.1.0     # via pytest
+numpy==1.16.4             # via matplotlib, scipy
+packaging==19.0           # via pytest
+pluggy==0.12.0            # via pytest
 py==1.8.0                 # via pytest
-pyparsing==2.3.1          # via matplotlib
-pytest-cov==2.6.1
-pytest==4.3.0             # via pytest-cov
+pyparsing==2.4.0          # via matplotlib, packaging
+pytest-cov==2.7.1
+pytest==5.0.1             # via pytest-cov
 python-dateutil==2.8.0    # via matplotlib
-scipy==1.2.1
-six==1.12.0               # via cycler, pytest, python-dateutil
+scipy==1.3.0
+six==1.12.0               # via cycler, packaging, python-dateutil
+wcwidth==0.1.7            # via pytest
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via kiwisolver, pytest
+# setuptools==41.0.1        # via kiwisolver


### PR DESCRIPTION
Update dependencies to address [Jinja security issue](https://nvd.nist.gov/vuln/detail/CVE-2019-10906).